### PR TITLE
onDisposeでのresetProperties取りやめ

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/com/example/jettodoapp/MainViewModel.kt
+++ b/app/src/main/java/com/example/jettodoapp/MainViewModel.kt
@@ -35,6 +35,7 @@ class MainViewModel @Inject constructor(private val taskDao: TaskDao) : ViewMode
             val newTask = Task(title = title, description = description)
             taskDao.insertTask(newTask)
             Log.d(MainViewModel::class.simpleName, "success create task")
+            resetProperties()
         }
     }
 
@@ -50,6 +51,7 @@ class MainViewModel @Inject constructor(private val taskDao: TaskDao) : ViewMode
                 task.title = title
                 task.description = description
                 taskDao.updateTask(task)
+                resetProperties()
             }
         }
     }

--- a/app/src/main/java/com/example/jettodoapp/components/EditDialog.kt
+++ b/app/src/main/java/com/example/jettodoapp/components/EditDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -14,14 +13,12 @@ import com.example.jettodoapp.MainViewModel
 
 @Composable
 fun EditDialog(viewModel: MainViewModel = hiltViewModel()) {
-    DisposableEffect(Unit) {
-        onDispose {
-            viewModel.resetProperties()
-        }
-    }
 
     AlertDialog(
-        onDismissRequest = { viewModel.isShowDialog = false },
+        onDismissRequest = {
+            viewModel.isShowDialog = false
+            viewModel.resetProperties()
+        },
         title = { Text(text = if (viewModel.isEditing) "タスク更新" else "タスク新規作成") },
         text = {
             Column {
@@ -42,7 +39,10 @@ fun EditDialog(viewModel: MainViewModel = hiltViewModel()) {
                 Spacer(modifier = Modifier.weight(1f))
                 Button(
                     modifier = Modifier.width(120.dp),
-                    onClick = { viewModel.isShowDialog = false },
+                    onClick = {
+                        viewModel.isShowDialog = false
+                        viewModel.resetProperties()
+                    },
                 ) {
                     Text(text = "キャンセル")
                 }


### PR DESCRIPTION
## 概要
- DisposableEffectのonDisposeブロック内で、resetPropertiesを呼ぶと、画面回転時に入力値がリセットされてしまうので、代わりに、ダイアログを非表示にするタイミングでresetPropertiesを呼ぶように変更

## やったこと
- DisposableEffectの削除
- onDismissRequestでのresetProperties呼び出し追加
- createTaskの最後にresetProperties呼び出し
- updateTaskの最後にresetProperties呼び出し